### PR TITLE
Fixing 500 on self.session.post()

### DIFF
--- a/tsrestapiv1.py
+++ b/tsrestapiv1.py
@@ -190,7 +190,7 @@ class TSRestApiV1:
         }
 
         url = self.base_url + endpoint
-        response = self.session.post(url=url, data=post_data)
+        response = self.session.post(url=url, params=post_data)
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
The post data needs to be sent via URL parameters, consistent with the swagger documentation.  This change converted the 500 I was getting to a 200.