### PR TITLE
Added fix for incorrect batch size on metadata_listobjectheaders method

### DIFF
--- a/endpoint_method_classes.py
+++ b/endpoint_method_classes.py
@@ -406,13 +406,13 @@ class AnswerMethods(SharedEndpointMethods):
 class WorksheetMethods(SharedEndpointMethods):
     def __init__(self, tsrest: TSRestApiV1):
         super().__init__(tsrest)
-        self.metadata_name = MetadataNames.WORKSHEEET
+        self.metadata_name = MetadataNames.WORKSHEET
         self.metadata_subtype = MetadataSubtypes.WORKSHEET
 
     def get_dependent_objects(self, worksheet_guids: List[str]):
         # July Cloud feature
         # Using dependency_listdependents because it is available in 7.1.1 and Cloud
-        return self.rest.dependency_listdependents(object_type=MetadataNames.WORKSHEEET, guids=worksheet_guids)
+        return self.rest.dependency_listdependents(object_type=MetadataNames.WORKSHEET, guids=worksheet_guids)
         # return self.rest.dependency_logicaltable(logical_table_guids=worksheet_guids)
 
     def get_dependent_pinboards_for_worksheet(self, worksheet_guid: str) -> List:
@@ -501,7 +501,7 @@ class TableMethods(SharedEndpointMethods):
 #    def get_dependent_objects(self, view_guids: List[str]):
 #        # July Cloud feature
 #        # Using dependency_listdependents because it is available in 7.1.1 and Cloud
-#        return self.rest.dependency_listdependents(object_type=MetadataNames.WORKSHEEET, guids=view_guids)
+#        return self.rest.dependency_listdependents(object_type=MetadataNames.WORKSHEET, guids=view_guids)
 #        #return self.rest.dependency_logicaltable(logical_table_guids=table_guids)
 
 

--- a/endpoint_method_classes.py
+++ b/endpoint_method_classes.py
@@ -35,7 +35,7 @@ class SharedEndpointMethods:
                                                         sort_ascending=sort_ascending,
                                                         filter=filter,
                                                         tagname=tags_filter,
-                                                        batchsize=-offset,
+                                                        batchsize=batchsize,
                                                         offset=offset)
 
     def find_guid(self, name: str) -> str:

--- a/examples/dependency_examples.py
+++ b/examples/dependency_examples.py
@@ -41,7 +41,7 @@ def get_dependent_objects_guid_map(dependent_objects_response):
         {
             MetadataNames.LIVEBOARD: [],
             MetadataNames.ANSWER: [],
-            MetadataNames.WORKSHEEET: [],
+            MetadataNames.WORKSHEET: [],
             MetadataNames.TABLE: []
         }
     )

--- a/examples/tml_and_sdlc/transfer_object_ownership.py
+++ b/examples/tml_and_sdlc/transfer_object_ownership.py
@@ -31,7 +31,7 @@ def get_guids_by_object_type():
     # However you determine which objects, packaged them up by types
     guid_return = { MetadataNames.LIVEBOARD : [] ,
                     MetadataNames.ANSWER : [] ,
-                    MetadataNames.WORKSHEEET: []
+                    MetadataNames.WORKSHEET: []
                     }
     return guid_return
 


### PR DESCRIPTION
The incorrect parameter was used for the `metadata_listobjectheaders` method for the `batchsize` parameter when `metadata_subtype` was not None. I also made an update to the documentation for the `tml_create_release_from_dev_on_disk.py` guide to make it clear that this particular example is not meant for single tenant deployments.